### PR TITLE
add a start command to simplify onboarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,7 @@
 FROM nginx:alpine
-COPY index.html /usr/share/nginx/html
+WORKDIR /var/okteto/sync
+COPY default.conf /etc/nginx/conf.d/default.conf
+COPY start start
+COPY index.html /var/okteto/sync
+CMD "./nginx"
+

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,21 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /var/okteto/sync;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/nginx
+++ b/nginx
@@ -1,0 +1,1 @@
+nginx -g "daemon off;"


### PR DESCRIPTION
With this, the manifest can be simplified to:

```
name: shiny-moon 
replicas: 1
public: true
containers:
  welcome:
    image: okteto/welcome:ramiro
    ports:
      - https:443:http:80
    dev:
      command: nginx
```